### PR TITLE
allow unauthenticated access flag for msk to be set by users of this …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,6 +151,7 @@ resource "aws_msk_cluster" "default" {
           iam   = var.client_sasl_iam_enabled
         }
       }
+      unauthenticated = var.client_allow_unauthenticated
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,12 @@ variable "certificate_authority_arns" {
   description = "List of ACM Certificate Authority Amazon Resource Names (ARNs) to be used for TLS client authentication"
 }
 
+variable "client_allow_unauthenticated" {
+  type        = bool
+  default     = false
+  description = "Enables unauthenticated access."
+}
+
 variable "client_sasl_scram_enabled" {
   type        = bool
   default     = false


### PR DESCRIPTION
Issue: https://github.com/deltastreaminc/deltastream-api/issues/2194

Allow unauthenticated access flag for msk cluster to be set by users of this module (MSK in control-plane and data-plane), once we have synced to upstream version, we will not need this patch. See upstream commit at https://tinyurl.com/possemskkafka

We need this flag as currently it is set to true by default, but once we turn on SASL the default aws terraform msk (or cloud possie) has been setting unauthenticated to disabled (false), this will break our existing service as we will be using two phase deployment to ensure zero down time to existing services expecting unauthenticated access to MSK (within VPC).

Deployment steps:

* Deploy terraform change to enable SASL (while keep the unauthenticated access on for existing K8s services running in control-plane/data-plane)
* Next once infra changes have been applied and verified and zero issue seen in existing deployment, then a separate ansible deployment will update debezium, api-server in control plane to use SASL auth using secrets stored in aws secret. 

Note the same will be applied on data-plane for store-proxy access to interactive store MKS.