### PR TITLE
unauthenticated flag was not consistently handled due to the for_each…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -136,7 +136,7 @@ resource "aws_msk_cluster" "default" {
   }
 
   dynamic "client_authentication" {
-    for_each = var.client_tls_auth_enabled || var.client_sasl_scram_enabled || var.client_sasl_iam_enabled ? [1] : []
+    for_each = [1]
     content {
       dynamic "tls" {
         for_each = var.client_tls_auth_enabled ? [1] : []


### PR DESCRIPTION
## what
unauthenticated flag was not consistently handled due to the for_each block restricted to one of the tls, sasl, and iam auth modes being enabled, this was causing inconsistency when only unauthenticated flag was passed (specifically, when was set to false).

Updated code to ensure unauthenticated flag is set to the passed variable independent of if any other auth mechanisms were passed by caller.


## why
Without this change the module acted inconsistently for [unauthenticated mode](https://github.com/deltastreaminc/terraform-aws-msk-apache-kafka-cluster/compare/master...deltastreaminc:terraform-aws-msk-apache-kafka-cluster:syed/handle_unauthenticated_flag_consistently?expand=1#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL154), specifically when user passes `client_allow_unauthenticated` variable as `false`  the module was relying on defaults from terraform/aws which sets unauthenticated to true in that case.
This change ensures that the module always take passed variable value for unauthenticated mode.

Do note that aws sdk will fail creation of an MSK where unauthenticated is set to false and no other auth mechanism is passed, which is fine as it will not be creating an inconsistent resource without caller of the module realizing the mistake.

## references
https://github.com/deltastreaminc/deltastream-api/issues/2194