### PR TITLE
support for gp3 ebs storage type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,10 @@ resource "aws_msk_cluster" "default" {
     instance_type   = var.broker_instance_type
     storage_info {
       ebs_storage_info {
+        provisioned_throughput {
+          enabled           = var.enable_provisioned_throughput
+          volume_throughput = var.provisioned_volume_throughput
+        }
         volume_size = var.broker_volume_size
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -190,3 +190,15 @@ variable "storage_autoscaling_disable_scale_in" {
   default     = false
   description = "If the value is true, scale in is disabled and the target tracking policy won't remove capacity from the scalable resource."
 }
+
+variable "enable_provisioned_throughput" {
+  type        = bool
+  default     = false
+  description = "Controls whether provisioned throughput is enabled or not. Default value: false."
+}
+
+variable "provisioned_volume_throughput" {
+  type        = number
+  default     = 250
+  description = "Throughput value of the EBS volumes for the data drive on each kafka broker node in MiB per second. The minimum value is 250. The maximum value varies between broker type. You can refer to the valid values for the maximum volume throughput at the following https://docs.aws.amazon.com/msk/latest/developerguide/msk-provision-throughput.html#throughput-bottlenecks"
+}


### PR DESCRIPTION
## what
AWS Recommends the use of gp3 for better cost efficiency within ebs volumes attached to the MSK brokers.

## references
https://aws.amazon.com/blogs/big-data/best-practices-for-right-sizing-your-apache-kafka-clusters-to-optimize-performance-and-cost/
https://docs.aws.amazon.com/msk/latest/developerguide/msk-provision-throughput.html#throughput-bottlenecks


